### PR TITLE
Fixes/pp 71/fix allow tokens scripts

### DIFF
--- a/contract-addresses.json
+++ b/contract-addresses.json
@@ -1,16 +1,1 @@
-{
-    "33": {
-        "penalizer": "0xe8C7C6f18c3B9532343487faD807060750C1fE95",
-        "relayHub": "0x3bA95e1cccd397b5124BcdCC5bf0952114E6A701",
-        "smartWallet": "0xB7a001eE69E7C1eef25Eb8e628e46214Ea74BF0F",
-        "smartWalletFactory": "0x8C1108cFCd7ddad09D8910e5f42982A6c54aD9cD",
-        "smartWalletDeployVerifier": "0x1938517B0762103d52590Ca21d459968c25c9E67",
-        "smartWalletRelayVerifier": "0x74Dc4471FA8C8fBE09c7a0C400a0852b0A9d04b2",
-        "customSmartWallet": "0x96A90Ee24C20c78Ba20AcE1a2aa4D59F79353C54",
-        "customSmartWalletFactory": "0x89bac3BB0517F7Dc0E5E94265217A9Acc5cc489f",
-        "customSmartWalletDeployVerifier": "0x3eE31F6049065B616f85470985c0eF067f2bEbDE",
-        "customSmartWalletRelayVerifier": "0xDE8Ae20488BE104f0782C0126038b6682ECc1eC7",
-        "sampleRecipient": "0xB08E0D333F139AC71DE04f4bfE7e75ca1e6122a0",
-        "testToken": "0x5D0aBdE7Ed6B7e122eD55EAe514E617d6c08f407"
-    }
-}
+{"33":{"penalizer":"0x7CFf7386dDC8af724AC46c97E00d42b70131e2B6","relayHub":"0x9DC4Ee9d379f2F2D3bEc094Ea5D68b179790D580","smartWallet":"0x0bf88c200cc8f5f2cA409a35adf69dcbFc2e6Caf","smartWalletFactory":"0x2Ec01561f6F2e2325630A58Eb1Be43c51d7bdf70","smartWalletDeployVerifier":"0xA5344b32BFeEB51bf70693bBFECe3F23d82c39bE","smartWalletRelayVerifier":"0x69788F628C5Db69AC37506573162Ac15C735f726","customSmartWallet":"0xAED72be45dd3206635183013E910f415c9732CCa","customSmartWalletFactory":"0xE9797325c5C3A841B4C4f03D15334e5401f9F78F","customSmartWalletDeployVerifier":"0x545c8EEA346855eF6961346dCc1568a1a028EA50","customSmartWalletRelayVerifier":"0xf02976B499c43FfC1Ec16611581e96C2A750ADcf","sampleRecipient":"0xb4ed846447053EA8502E9292edbC8620CAe3F386","testToken":"0x896A78a1d3E37588079D984291b09532916ae6CB"},"regtest":{"penalizer":"0xe8C7C6f18c3B9532343487faD807060750C1fE95","relayHub":"0x3bA95e1cccd397b5124BcdCC5bf0952114E6A701","smartWallet":"0xB7a001eE69E7C1eef25Eb8e628e46214Ea74BF0F","smartWalletFactory":"0x8C1108cFCd7ddad09D8910e5f42982A6c54aD9cD","smartWalletDeployVerifier":"0x1938517B0762103d52590Ca21d459968c25c9E67","smartWalletRelayVerifier":"0x74Dc4471FA8C8fBE09c7a0C400a0852b0A9d04b2","customSmartWallet":"0x96A90Ee24C20c78Ba20AcE1a2aa4D59F79353C54","customSmartWalletFactory":"0x89bac3BB0517F7Dc0E5E94265217A9Acc5cc489f","customSmartWalletDeployVerifier":"0x3eE31F6049065B616f85470985c0eF067f2bEbDE","customSmartWalletRelayVerifier":"0xDE8Ae20488BE104f0782C0126038b6682ECc1eC7","sampleRecipient":"0xB08E0D333F139AC71DE04f4bfE7e75ca1e6122a0","testToken":"0x5D0aBdE7Ed6B7e122eD55EAe514E617d6c08f407"}}

--- a/contract-addresses.json
+++ b/contract-addresses.json
@@ -1,1 +1,16 @@
-{"33":{"penalizer":"0x7CFf7386dDC8af724AC46c97E00d42b70131e2B6","relayHub":"0x9DC4Ee9d379f2F2D3bEc094Ea5D68b179790D580","smartWallet":"0x0bf88c200cc8f5f2cA409a35adf69dcbFc2e6Caf","smartWalletFactory":"0x2Ec01561f6F2e2325630A58Eb1Be43c51d7bdf70","smartWalletDeployVerifier":"0xA5344b32BFeEB51bf70693bBFECe3F23d82c39bE","smartWalletRelayVerifier":"0x69788F628C5Db69AC37506573162Ac15C735f726","customSmartWallet":"0xAED72be45dd3206635183013E910f415c9732CCa","customSmartWalletFactory":"0xE9797325c5C3A841B4C4f03D15334e5401f9F78F","customSmartWalletDeployVerifier":"0x545c8EEA346855eF6961346dCc1568a1a028EA50","customSmartWalletRelayVerifier":"0xf02976B499c43FfC1Ec16611581e96C2A750ADcf","sampleRecipient":"0xb4ed846447053EA8502E9292edbC8620CAe3F386","testToken":"0x896A78a1d3E37588079D984291b09532916ae6CB"},"regtest":{"penalizer":"0xe8C7C6f18c3B9532343487faD807060750C1fE95","relayHub":"0x3bA95e1cccd397b5124BcdCC5bf0952114E6A701","smartWallet":"0xB7a001eE69E7C1eef25Eb8e628e46214Ea74BF0F","smartWalletFactory":"0x8C1108cFCd7ddad09D8910e5f42982A6c54aD9cD","smartWalletDeployVerifier":"0x1938517B0762103d52590Ca21d459968c25c9E67","smartWalletRelayVerifier":"0x74Dc4471FA8C8fBE09c7a0C400a0852b0A9d04b2","customSmartWallet":"0x96A90Ee24C20c78Ba20AcE1a2aa4D59F79353C54","customSmartWalletFactory":"0x89bac3BB0517F7Dc0E5E94265217A9Acc5cc489f","customSmartWalletDeployVerifier":"0x3eE31F6049065B616f85470985c0eF067f2bEbDE","customSmartWalletRelayVerifier":"0xDE8Ae20488BE104f0782C0126038b6682ECc1eC7","sampleRecipient":"0xB08E0D333F139AC71DE04f4bfE7e75ca1e6122a0","testToken":"0x5D0aBdE7Ed6B7e122eD55EAe514E617d6c08f407"}}
+{
+    "regtest": {
+        "penalizer": "0x7CFf7386dDC8af724AC46c97E00d42b70131e2B6",
+        "relayHub": "0x9DC4Ee9d379f2F2D3bEc094Ea5D68b179790D580",
+        "smartWallet": "0x0bf88c200cc8f5f2cA409a35adf69dcbFc2e6Caf",
+        "smartWalletFactory": "0x2Ec01561f6F2e2325630A58Eb1Be43c51d7bdf70",
+        "smartWalletDeployVerifier": "0xA5344b32BFeEB51bf70693bBFECe3F23d82c39bE",
+        "smartWalletRelayVerifier": "0x69788F628C5Db69AC37506573162Ac15C735f726",
+        "customSmartWallet": "0xAED72be45dd3206635183013E910f415c9732CCa",
+        "customSmartWalletFactory": "0xE9797325c5C3A841B4C4f03D15334e5401f9F78F",
+        "customSmartWalletDeployVerifier": "0x545c8EEA346855eF6961346dCc1568a1a028EA50",
+        "customSmartWalletRelayVerifier": "0xf02976B499c43FfC1Ec16611581e96C2A750ADcf",
+        "sampleRecipient": "0xb4ed846447053EA8502E9292edbC8620CAe3F386",
+        "testToken": "0x896A78a1d3E37588079D984291b09532916ae6CB"
+    }
+}

--- a/contract-addresses.json
+++ b/contract-addresses.json
@@ -1,1 +1,16 @@
-{"regtest":{"penalizer":"0x7CFf7386dDC8af724AC46c97E00d42b70131e2B6","relayHub":"0x9DC4Ee9d379f2F2D3bEc094Ea5D68b179790D580","smartWallet":"0x0bf88c200cc8f5f2cA409a35adf69dcbFc2e6Caf","smartWalletFactory":"0x2Ec01561f6F2e2325630A58Eb1Be43c51d7bdf70","smartWalletDeployVerifier":"0xA5344b32BFeEB51bf70693bBFECe3F23d82c39bE","smartWalletRelayVerifier":"0x69788F628C5Db69AC37506573162Ac15C735f726","customSmartWallet":"0xAED72be45dd3206635183013E910f415c9732CCa","customSmartWalletFactory":"0xE9797325c5C3A841B4C4f03D15334e5401f9F78F","customSmartWalletDeployVerifier":"0x545c8EEA346855eF6961346dCc1568a1a028EA50","customSmartWalletRelayVerifier":"0xf02976B499c43FfC1Ec16611581e96C2A750ADcf","sampleRecipient":"0xb4ed846447053EA8502E9292edbC8620CAe3F386","testToken":"0x896A78a1d3E37588079D984291b09532916ae6CB"},"regtest":{"penalizer":"0xe8C7C6f18c3B9532343487faD807060750C1fE95","relayHub":"0x3bA95e1cccd397b5124BcdCC5bf0952114E6A701","smartWallet":"0xB7a001eE69E7C1eef25Eb8e628e46214Ea74BF0F","smartWalletFactory":"0x8C1108cFCd7ddad09D8910e5f42982A6c54aD9cD","smartWalletDeployVerifier":"0x1938517B0762103d52590Ca21d459968c25c9E67","smartWalletRelayVerifier":"0x74Dc4471FA8C8fBE09c7a0C400a0852b0A9d04b2","customSmartWallet":"0x96A90Ee24C20c78Ba20AcE1a2aa4D59F79353C54","customSmartWalletFactory":"0x89bac3BB0517F7Dc0E5E94265217A9Acc5cc489f","customSmartWalletDeployVerifier":"0x3eE31F6049065B616f85470985c0eF067f2bEbDE","customSmartWalletRelayVerifier":"0xDE8Ae20488BE104f0782C0126038b6682ECc1eC7","sampleRecipient":"0xB08E0D333F139AC71DE04f4bfE7e75ca1e6122a0","testToken":"0x5D0aBdE7Ed6B7e122eD55EAe514E617d6c08f407"}}
+{
+    "regtest": {
+        "penalizer": "0xe8C7C6f18c3B9532343487faD807060750C1fE95",
+        "relayHub": "0x3bA95e1cccd397b5124BcdCC5bf0952114E6A701",
+        "smartWallet": "0xB7a001eE69E7C1eef25Eb8e628e46214Ea74BF0F",
+        "smartWalletFactory": "0x8C1108cFCd7ddad09D8910e5f42982A6c54aD9cD",
+        "smartWalletDeployVerifier": "0x1938517B0762103d52590Ca21d459968c25c9E67",
+        "smartWalletRelayVerifier": "0x74Dc4471FA8C8fBE09c7a0C400a0852b0A9d04b2",
+        "customSmartWallet": "0x96A90Ee24C20c78Ba20AcE1a2aa4D59F79353C54",
+        "customSmartWalletFactory": "0x89bac3BB0517F7Dc0E5E94265217A9Acc5cc489f",
+        "customSmartWalletDeployVerifier": "0x3eE31F6049065B616f85470985c0eF067f2bEbDE",
+        "customSmartWalletRelayVerifier": "0xDE8Ae20488BE104f0782C0126038b6682ECc1eC7",
+        "sampleRecipient": "0xB08E0D333F139AC71DE04f4bfE7e75ca1e6122a0",
+        "testToken": "0x5D0aBdE7Ed6B7e122eD55EAe514E617d6c08f407"
+    }
+}

--- a/contract-addresses.json
+++ b/contract-addresses.json
@@ -1,16 +1,1 @@
-{
-    "regtest": {
-        "penalizer": "0x7CFf7386dDC8af724AC46c97E00d42b70131e2B6",
-        "relayHub": "0x9DC4Ee9d379f2F2D3bEc094Ea5D68b179790D580",
-        "smartWallet": "0x0bf88c200cc8f5f2cA409a35adf69dcbFc2e6Caf",
-        "smartWalletFactory": "0x2Ec01561f6F2e2325630A58Eb1Be43c51d7bdf70",
-        "smartWalletDeployVerifier": "0xA5344b32BFeEB51bf70693bBFECe3F23d82c39bE",
-        "smartWalletRelayVerifier": "0x69788F628C5Db69AC37506573162Ac15C735f726",
-        "customSmartWallet": "0xAED72be45dd3206635183013E910f415c9732CCa",
-        "customSmartWalletFactory": "0xE9797325c5C3A841B4C4f03D15334e5401f9F78F",
-        "customSmartWalletDeployVerifier": "0x545c8EEA346855eF6961346dCc1568a1a028EA50",
-        "customSmartWalletRelayVerifier": "0xf02976B499c43FfC1Ec16611581e96C2A750ADcf",
-        "sampleRecipient": "0xb4ed846447053EA8502E9292edbC8620CAe3F386",
-        "testToken": "0x896A78a1d3E37588079D984291b09532916ae6CB"
-    }
-}
+{"regtest":{"penalizer":"0x7CFf7386dDC8af724AC46c97E00d42b70131e2B6","relayHub":"0x9DC4Ee9d379f2F2D3bEc094Ea5D68b179790D580","smartWallet":"0x0bf88c200cc8f5f2cA409a35adf69dcbFc2e6Caf","smartWalletFactory":"0x2Ec01561f6F2e2325630A58Eb1Be43c51d7bdf70","smartWalletDeployVerifier":"0xA5344b32BFeEB51bf70693bBFECe3F23d82c39bE","smartWalletRelayVerifier":"0x69788F628C5Db69AC37506573162Ac15C735f726","customSmartWallet":"0xAED72be45dd3206635183013E910f415c9732CCa","customSmartWalletFactory":"0xE9797325c5C3A841B4C4f03D15334e5401f9F78F","customSmartWalletDeployVerifier":"0x545c8EEA346855eF6961346dCc1568a1a028EA50","customSmartWalletRelayVerifier":"0xf02976B499c43FfC1Ec16611581e96C2A750ADcf","sampleRecipient":"0xb4ed846447053EA8502E9292edbC8620CAe3F386","testToken":"0x896A78a1d3E37588079D984291b09532916ae6CB"},"regtest":{"penalizer":"0xe8C7C6f18c3B9532343487faD807060750C1fE95","relayHub":"0x3bA95e1cccd397b5124BcdCC5bf0952114E6A701","smartWallet":"0xB7a001eE69E7C1eef25Eb8e628e46214Ea74BF0F","smartWalletFactory":"0x8C1108cFCd7ddad09D8910e5f42982A6c54aD9cD","smartWalletDeployVerifier":"0x1938517B0762103d52590Ca21d459968c25c9E67","smartWalletRelayVerifier":"0x74Dc4471FA8C8fBE09c7a0C400a0852b0A9d04b2","customSmartWallet":"0x96A90Ee24C20c78Ba20AcE1a2aa4D59F79353C54","customSmartWalletFactory":"0x89bac3BB0517F7Dc0E5E94265217A9Acc5cc489f","customSmartWalletDeployVerifier":"0x3eE31F6049065B616f85470985c0eF067f2bEbDE","customSmartWalletRelayVerifier":"0xDE8Ae20488BE104f0782C0126038b6682ECc1eC7","sampleRecipient":"0xB08E0D333F139AC71DE04f4bfE7e75ca1e6122a0","testToken":"0x5D0aBdE7Ed6B7e122eD55EAe514E617d6c08f407"}}

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -108,10 +108,7 @@ module.exports = async function (deployer, network, accounts) {
         jsonConfig = {};
     }
 
-    const networkConfiguration = truffleConfig.networks[network];
-    const networkId = networkConfiguration.network_id;
-
-    jsonConfig[networkId] = {
+    jsonConfig[network] = {
         penalizer: Penalizer.address,
         relayHub: RelayHub.address,
         smartWallet: SmartWallet.address,

--- a/scripts/allowTokens
+++ b/scripts/allowTokens
@@ -86,6 +86,7 @@ module.exports = async function(callback) {
       }
     }
   } catch (error) {
+    console.error(error);
     console.error("Fail to allow tokens");
     return;
   }

--- a/scripts/allowTokens
+++ b/scripts/allowTokens
@@ -87,7 +87,7 @@ module.exports = async function(callback) {
     }
   } catch (error) {
     console.error(error);
-    console.error("Fail to allow tokens");
+    console.error("Failed to allow tokens");
     return;
   }
   console.log("Tokens allowed successfully!");

--- a/scripts/allowTokens
+++ b/scripts/allowTokens
@@ -14,32 +14,7 @@ fi
 
 cat > allowTokens.js << EOF
 
-async function getRevertReason(txHash) {
-  const tx = await web3.eth.getTransaction(txHash);
-  const txBlockNumber = tx.blockNumber;
-  try {
-
-    delete tx['hash'];
-    delete tx['blockHash'];
-    delete tx['blockNumber'];
-    delete tx['transactionIndex'];
-    delete tx['v'];
-    delete tx['r'];
-    delete tx['s'];
-
-    let result = await web3.eth.call(tx, txBlockNumber);
-    result = result.startsWith('0x') ? result : '0x' + result;
-    if (result && result.substr(138)) {
-      return web3.utils.toAscii(result.substr(138));
-    } else {
-      return 'Cannot get reason - No return value';
-    }
-  } catch (reason) {
-    return reason;
-  }
-}
-
-module.exports = async function(callback) {
+module.exports = async function( ) {
   const contractAddresses = require('./contract-addresses.json');
   const smartWalletDeployVerifierAbi = require("./build/contracts/DeployVerifier.json").abi;
   const customSmartWalletDeployVerifierAbi = require("./build/contracts/CustomSmartWalletDeployVerifier.json").abi;
@@ -59,29 +34,25 @@ module.exports = async function(callback) {
       try {
         await smartWalletDeployVerifier.methods.acceptToken(tokenAddress).send({from: accounts[0]});
       } catch (error) {
-        const reason = await getRevertReason(error.receipt.transactionHash);
-        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on smart wallet deploy verifier", reason);
+        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on smart wallet deploy verifier", error);
         throw error;
       }
       try {
         await smartWalletRelayVerifier.methods.acceptToken(tokenAddress).send({from: accounts[0]});
       } catch (error) {
-        const reason = await getRevertReason(error.receipt.transactionHash);
-        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on smart wallet relay verifier", reason);
+        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on smart wallet relay verifier", error);
         throw error;
       }
       try {
         await customSmartWalletDeployVerifier.methods.acceptToken(tokenAddress).send({from: accounts[0]});
       } catch (error) {
-        const reason = await getRevertReason(error.receipt.transactionHash);
-        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on custom smart deploy verifier", reason);
+        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on custom smart deploy verifier", error);
         throw error;
       }
       try {
         await customSmartWalletRelayVerifier.methods.acceptToken(tokenAddress).send({from: accounts[0]});
       } catch (error) {
-        const reason = await getRevertReason(error.receipt.transactionHash);
-        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on custom smart wallet relay verifier", reason);
+        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on custom smart wallet relay verifier", error);
         throw error;
       }
     }

--- a/scripts/allowTokens
+++ b/scripts/allowTokens
@@ -14,6 +14,29 @@ fi
 
 cat > allowTokens.js << EOF
 
+async function getRevertReason(txHash) {
+  const tx = await web3.eth.getTransaction(txHash);
+  const txBlockNumber = tx.blockNumber;
+  try {
+    delete tx['hash'];
+    delete tx['blockHash'];
+    delete tx['blockNumber'];
+    delete tx['transactionIndex'];
+    delete tx['v'];
+    delete tx['r'];
+    delete tx['s'];
+    let result = await web3.eth.call(tx, txBlockNumber);
+    result = result.startsWith('0x') ? result : '0x' + result;
+    if (result && result.substr(138)) {
+      return web3.utils.toAscii(result.substr(138));
+    } else {
+      return 'Cannot get reason - No return value';
+    }
+  } catch (reason) {
+    return reason;
+  }
+}
+
 module.exports = async function( ) {
   const contractAddresses = require('./contract-addresses.json');
   const smartWalletDeployVerifierAbi = require("./build/contracts/DeployVerifier.json").abi;
@@ -34,25 +57,29 @@ module.exports = async function( ) {
       try {
         await smartWalletDeployVerifier.methods.acceptToken(tokenAddress).send({from: accounts[0]});
       } catch (error) {
-        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on smart wallet deploy verifier", error);
+        const reason = error.receipt? await getRevertReason(error.receipt.transactionHash) : error;
+        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on smart wallet deploy verifier", reason);
         throw error;
       }
       try {
         await smartWalletRelayVerifier.methods.acceptToken(tokenAddress).send({from: accounts[0]});
       } catch (error) {
-        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on smart wallet relay verifier", error);
+        const reason = error.receipt? await getRevertReason(error.receipt.transactionHash) : error;
+        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on smart wallet relay verifier", reason);
         throw error;
       }
       try {
         await customSmartWalletDeployVerifier.methods.acceptToken(tokenAddress).send({from: accounts[0]});
       } catch (error) {
-        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on custom smart deploy verifier", error);
+        const reason = error.receipt? await getRevertReason(error.receipt.transactionHash) : error;
+        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on custom smart deploy verifier", reason);
         throw error;
       }
       try {
         await customSmartWalletRelayVerifier.methods.acceptToken(tokenAddress).send({from: accounts[0]});
       } catch (error) {
-        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on custom smart wallet relay verifier", error);
+        const reason = error.receipt? await getRevertReason(error.receipt.transactionHash) : error;
+        console.error("Error adding token with address " + tokenAddress + " to allowed tokens on custom smart wallet relay verifier", reason);
         throw error;
       }
     }

--- a/scripts/allowTokens
+++ b/scripts/allowTokens
@@ -1,15 +1,15 @@
 #!/bin/bash
 
 TOKEN_ADDRESSES=$1
-NETWORK_ID=$2
+NETWORK_NAME=$2
 
 if [ "${TOKEN_ADDRESSES}" == "" ]; then
         echo "You need to specify at least one token address."
         exit 1
 fi
 
-if [ "${NETWORK_ID}" == "" ]; then
-        NETWORK_ID="regtest"
+if [ "${NETWORK_NAME}" == "" ]; then
+        NETWORK_NAME="regtest"
 fi
 
 cat > allowTokens.js << EOF
@@ -45,10 +45,10 @@ module.exports = async function(callback) {
   const customSmartWalletDeployVerifierAbi = require("./build/contracts/CustomSmartWalletDeployVerifier.json").abi;
   const relayVerifierAbi = require("./build/contracts/RelayVerifier.json").abi;
 
-  const smartWalletDeployVerifier = await new web3.eth.Contract(smartWalletDeployVerifierAbi, contractAddresses["${NETWORK_ID}"].smartWalletDeployVerifier);
-  const smartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_ID}"].smartWalletRelayVerifier);
-  const customSmartWalletDeployVerifier = await new web3.eth.Contract(customSmartWalletDeployVerifierAbi, contractAddresses["${NETWORK_ID}"].customSmartWalletDeployVerifier);
-  const customSmartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_ID}"].customSmartWalletRelayVerifier);
+  const smartWalletDeployVerifier = await new web3.eth.Contract(smartWalletDeployVerifierAbi, contractAddresses["${NETWORK_NAME}"].smartWalletDeployVerifier);
+  const smartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_NAME}"].smartWalletRelayVerifier);
+  const customSmartWalletDeployVerifier = await new web3.eth.Contract(customSmartWalletDeployVerifierAbi, contractAddresses["${NETWORK_NAME}"].customSmartWalletDeployVerifier);
+  const customSmartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_NAME}"].customSmartWalletRelayVerifier);
 
   const tokenAddresses = '${TOKEN_ADDRESSES}'.split(',');
 
@@ -94,6 +94,6 @@ module.exports = async function(callback) {
 }
 EOF
 
-truffle exec --network ${NETWORK_ID} allowTokens.js
+truffle exec --network ${NETWORK_NAME} allowTokens.js
 
 rm allowTokens.js

--- a/scripts/allowedTokens
+++ b/scripts/allowedTokens
@@ -1,9 +1,9 @@
 #!/bin/bash
 
-NETWORK_ID=$1
+NETWORK_NAME=$1
 
-if [ "${NETWORK_ID}" == "" ]; then
-        NETWORK_ID="regtest"
+if [ "${NETWORK_NAME}" == "" ]; then
+        NETWORK_NAME="regtest"
 fi
 
 cat > allowTokens.js << EOF
@@ -13,10 +13,10 @@ module.exports = async function(callback) {
   const customSmartWalletDeployVerifierAbi = require("./build/contracts/CustomSmartWalletDeployVerifier.json").abi;
   const relayVerifierAbi = require("./build/contracts/RelayVerifier.json").abi;
 
-  const smartWalletDeployVerifier = await new web3.eth.Contract(smartWalletDeployVerifierAbi, contractAddresses["${NETWORK_ID}"].smartWalletDeployVerifier);
-  const smartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_ID}"].smartWalletRelayVerifier);
-  const customSmartWalletDeployVerifier = await new web3.eth.Contract(customSmartWalletDeployVerifierAbi, contractAddresses["${NETWORK_ID}"].customSmartWalletDeployVerifier);
-  const customSmartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_ID}"].customSmartWalletRelayVerifier);
+  const smartWalletDeployVerifier = await new web3.eth.Contract(smartWalletDeployVerifierAbi, contractAddresses["${NETWORK_NAME}"].smartWalletDeployVerifier);
+  const smartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_NAME}"].smartWalletRelayVerifier);
+  const customSmartWalletDeployVerifier = await new web3.eth.Contract(customSmartWalletDeployVerifierAbi, contractAddresses["${NETWORK_NAME}"].customSmartWalletDeployVerifier);
+  const customSmartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_NAME}"].customSmartWalletRelayVerifier);
 
   const accounts = await web3.eth.getAccounts();
 
@@ -56,6 +56,6 @@ module.exports = async function(callback) {
 }
 EOF
 
-truffle exec --network ${NETWORK_ID} allowTokens.js
+truffle exec --network ${NETWORK_NAME} allowTokens.js
 
 rm allowTokens.js

--- a/scripts/allowedTokens
+++ b/scripts/allowedTokens
@@ -6,7 +6,7 @@ if [ "${NETWORK_NAME}" == "" ]; then
         NETWORK_NAME="regtest"
 fi
 
-cat > allowTokens.js << EOF
+cat > allowedTokens.js << EOF
 module.exports = async function(callback) {
   const contractAddresses = require('./contract-addresses.json');
   const smartWalletDeployVerifierAbi = require("./build/contracts/DeployVerifier.json").abi;
@@ -56,6 +56,6 @@ module.exports = async function(callback) {
 }
 EOF
 
-truffle exec --network ${NETWORK_NAME} allowTokens.js
+truffle exec --network ${NETWORK_NAME} allowedTokens.js
 
-rm allowTokens.js
+rm allowedTokens.js

--- a/scripts/allowedTokens
+++ b/scripts/allowedTokens
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NETWORK_ID=$2
+NETWORK_ID=$1
 
 if [ "${NETWORK_ID}" == "" ]; then
         NETWORK_ID="regtest"


### PR DESCRIPTION
It seems there are some issues with the current version of the allowTokens and allowedTokens scripts, under the rif-relay-contracts repo.

It appears that:

network names are used during deployment (e.g. development) but IDs are used both in the contract-addresses.json file as well as the tokens scripts.

the allowedTokens script uses $2 as the network parameter name, instead of $1.

not all errors are displaying in the console in case something goes wrong.

Verify and fix this.

Also: update the Sample dApp readme so that the allow tokens section points to the rif-relay-contracts repo, once it works OK.