### PR TITLE
PP-98/Change the network name to network id

### DIFF
--- a/contract-addresses.json
+++ b/contract-addresses.json
@@ -1,5 +1,5 @@
 {
-    "regtest": {
+    "33": {
         "penalizer": "0xe8C7C6f18c3B9532343487faD807060750C1fE95",
         "relayHub": "0x3bA95e1cccd397b5124BcdCC5bf0952114E6A701",
         "smartWallet": "0xB7a001eE69E7C1eef25Eb8e628e46214Ea74BF0F",

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -20,7 +20,7 @@ const CustomSmartWalletDeployVerifier = artifacts.require(
     'CustomSmartWalletDeployVerifier'
 );
 
-module.exports = async function (deployer, network, accounts) {
+module.exports = async function (deployer, network) {
     await deployer.deploy(Penalizer);
     await deployer.deploy(RelayHub, Penalizer.address, 1, 1, 1, 1);
     await deployer.deploy(SmartWallet);
@@ -108,7 +108,10 @@ module.exports = async function (deployer, network, accounts) {
         jsonConfig = {};
     }
 
-    jsonConfig[network] = {
+    const networkConfiguration = truffleConfig.networks[network];
+    const networkId = networkConfiguration.network_id;
+
+    jsonConfig[networkId] = {
         penalizer: Penalizer.address,
         relayHub: RelayHub.address,
         smartWallet: SmartWallet.address,

--- a/scripts/allowTokens
+++ b/scripts/allowTokens
@@ -38,15 +38,20 @@ async function getRevertReason(txHash) {
 }
 
 module.exports = async function( ) {
+  const truffleConfig = require('./truffle');
   const contractAddresses = require('./contract-addresses.json');
+
+  const networkConfiguration = truffleConfig.networks["${NETWORK_NAME}"];
+  const networkId = networkConfiguration.network_id;
+
   const smartWalletDeployVerifierAbi = require("./build/contracts/DeployVerifier.json").abi;
   const customSmartWalletDeployVerifierAbi = require("./build/contracts/CustomSmartWalletDeployVerifier.json").abi;
   const relayVerifierAbi = require("./build/contracts/RelayVerifier.json").abi;
 
-  const smartWalletDeployVerifier = await new web3.eth.Contract(smartWalletDeployVerifierAbi, contractAddresses["${NETWORK_NAME}"].smartWalletDeployVerifier);
-  const smartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_NAME}"].smartWalletRelayVerifier);
-  const customSmartWalletDeployVerifier = await new web3.eth.Contract(customSmartWalletDeployVerifierAbi, contractAddresses["${NETWORK_NAME}"].customSmartWalletDeployVerifier);
-  const customSmartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_NAME}"].customSmartWalletRelayVerifier);
+  const smartWalletDeployVerifier = await new web3.eth.Contract(smartWalletDeployVerifierAbi, contractAddresses[networkId].smartWalletDeployVerifier);
+  const smartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses[networkId].smartWalletRelayVerifier);
+  const customSmartWalletDeployVerifier = await new web3.eth.Contract(customSmartWalletDeployVerifierAbi, contractAddresses[networkId].customSmartWalletDeployVerifier);
+  const customSmartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses[networkId].customSmartWalletRelayVerifier);
 
   const tokenAddresses = '${TOKEN_ADDRESSES}'.split(',');
 

--- a/scripts/allowedTokens
+++ b/scripts/allowedTokens
@@ -8,15 +8,20 @@ fi
 
 cat > allowedTokens.js << EOF
 module.exports = async function(callback) {
+  const truffleConfig = require('./truffle');
   const contractAddresses = require('./contract-addresses.json');
+
+  const networkConfiguration = truffleConfig.networks["${NETWORK_NAME}"];
+  const networkId = networkConfiguration.network_id;
+
   const smartWalletDeployVerifierAbi = require("./build/contracts/DeployVerifier.json").abi;
   const customSmartWalletDeployVerifierAbi = require("./build/contracts/CustomSmartWalletDeployVerifier.json").abi;
   const relayVerifierAbi = require("./build/contracts/RelayVerifier.json").abi;
 
-  const smartWalletDeployVerifier = await new web3.eth.Contract(smartWalletDeployVerifierAbi, contractAddresses["${NETWORK_NAME}"].smartWalletDeployVerifier);
-  const smartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_NAME}"].smartWalletRelayVerifier);
-  const customSmartWalletDeployVerifier = await new web3.eth.Contract(customSmartWalletDeployVerifierAbi, contractAddresses["${NETWORK_NAME}"].customSmartWalletDeployVerifier);
-  const customSmartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses["${NETWORK_NAME}"].customSmartWalletRelayVerifier);
+  const smartWalletDeployVerifier = await new web3.eth.Contract(smartWalletDeployVerifierAbi, contractAddresses[networkId].smartWalletDeployVerifier);
+  const smartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses[networkId].smartWalletRelayVerifier);
+  const customSmartWalletDeployVerifier = await new web3.eth.Contract(customSmartWalletDeployVerifierAbi, contractAddresses[networkId].customSmartWalletDeployVerifier);
+  const customSmartWalletRelayVerifier = await new web3.eth.Contract(relayVerifierAbi, contractAddresses[networkId].customSmartWalletRelayVerifier);
 
   const accounts = await web3.eth.getAccounts();
 


### PR DESCRIPTION
## What
Revert change that replace the id of the network to the name. This change is on migrate and contract-addresses.json.

## Why
On relaying services SDK have error because they not get the contract list from rif-relay-contracts contract-addresses file.

## Refs
[Change the network name](https://rsklabs.atlassian.net/browse/PP-98)

Revert change on rif-relay-contracts to change the network name x the network id.
Modify the deploy migration and make this changes.
