### PR TITLE
PP 95: Fix deploy on testnet

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@openzeppelin/contracts": "~3.2.0",
     "@truffle/contract": "4.2.23",
     "@truffle/contract-schema": "3.3.2",
-    "@truffle/hdwallet-provider": "1.2.4",
+    "@truffle/hdwallet-provider": "1.6.0",
     "@types/node": "~13.13.4",
     "patch-package": "~6.4.6",
     "truffle-hdwallet-provider": "~1.0.17"


### PR DESCRIPTION
## What

- Update the `@truffle/hdwallet-provider` package

## Why

- When we try to deploy the contracts on `testnet` the following error is raised: `"Migrations" -- Unknown Error: {"jsonrpc":"2.0","id":615502292974733,"error":{"code":-32602,"message":"Missing parameter, gasPrice, gas or value"}}`. After trying solutions, I discovered it could have been associated with the provider set in the testnet configuration, so I updated it to the latest version.