### PR TITLE
Fix the code that waits for the transaction receipt

### DIFF
--- a/tasks/send-multisig.js
+++ b/tasks/send-multisig.js
@@ -5,7 +5,7 @@ const argv = yargs(hideBin(process.argv)).parserConfiguration({
     'parse-numbers': false
 }).argv;
 const { default: Safe, Web3Adapter } = safeCoreSdk;
-const { contractNetworks, signWithAddress } = require('./utils');
+const { contractNetworks, signWithAddress, getTransactionReceipt } = require('./utils');
 const RevenueSharingAddresses = require('../revenue-sharing-addresses.json');
 
 const EMPTY_DATA = '0x';
@@ -78,8 +78,7 @@ module.exports = async (callback) => {
 
     // owners[0] executes (and implicitly signs) the transaction
     const safeTxResponse = await safeSdk.executeTransaction(safeTransaction, {gasLimit:'1081903'});
-
-    await safeTxResponse.transactionResponse?.wait();
+    await getTransactionReceipt(web3, safeTxResponse.hash);
     
     // print the balance after the transaction execution
     const balanceReceiverAfter = await web3.eth.getBalance(receiver);

--- a/tasks/utils.js
+++ b/tasks/utils.js
@@ -30,7 +30,7 @@ const sleep = async (milliseconds) => {
  * @param {number} initialBackoff initial time to wait for. Each time the receipt is not available it will multiplied by 2.
  * @returns 
  */
-const getTransactionReceipt= async (
+const getTransactionReceipt = async (
     web3,
     transactionHash,
     retries = WAIT_FOR_RECEIPT_RETRIES,

--- a/tasks/utils.js
+++ b/tasks/utils.js
@@ -13,6 +13,48 @@ const getCollectorInstance = async (artifacts) => {
     return collectorInstance;
 };
 
+const WAIT_FOR_RECEIPT_RETRIES = 6;
+const WAIT_FOR_RECEIPT_INITIAL_BACKOFF = 1000;
+
+const sleep = async (milliseconds) => {
+    return await new Promise((resolve) => setTimeout(resolve, milliseconds));
+};
+
+/**
+ * Extracted from rif-relay-common.js, it waits for a transaction receipt to be available or
+ * it throws an error after a number of tries.
+ * 
+ * @param {Web3} web3 Web3.js
+ * @param {string} transactionHash transaction hash
+ * @param {number} retries number of times to retries
+ * @param {number} initialBackoff initial time to wait for. Each time the receipt is not available it will multiplied by 2.
+ * @returns 
+ */
+const getTransactionReceipt= async (
+    web3,
+    transactionHash,
+    retries = WAIT_FOR_RECEIPT_RETRIES,
+    initialBackoff = WAIT_FOR_RECEIPT_INITIAL_BACKOFF
+) => {
+    for (
+        let tryCount = 0, backoff = initialBackoff;
+        tryCount < retries;
+        tryCount++, backoff *= 2
+    ) {
+        const receipt = await web3.eth.getTransactionReceipt(
+            transactionHash
+        );
+        // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+        if (receipt) {
+            return receipt;
+        }
+        await sleep(backoff);
+    }
+    throw new Error(
+        `No receipt found for this transaction ${transactionHash}`
+    );
+};
+
 const signWithAddress = async (web3, safeSdk, safeTransaction, owner) => {
     const ethAdapterOwner = new Web3Adapter({
         web3,
@@ -24,7 +66,7 @@ const signWithAddress = async (web3, safeSdk, safeTransaction, owner) => {
     });
     const txHash = await safeSdk2.getTransactionHash(safeTransaction);
     const approveTxResponse = await safeSdk2.approveTransactionHash(txHash);
-    await approveTxResponse.transactionResponse?.wait();
+    return await getTransactionReceipt(web3, approveTxResponse.hash);
 };
 
 const safeProxyFactoryAddress = '0x73ec81da0C72DD112e06c09A6ec03B5544d26F05';
@@ -42,5 +84,6 @@ module.exports = {
     getTestTokenInstance,
     getCollectorInstance,
     signWithAddress,
-    contractNetworks
+    contractNetworks,
+    getTransactionReceipt
 };

--- a/tasks/withdraw.js
+++ b/tasks/withdraw.js
@@ -5,7 +5,8 @@ const {
     getTestTokenInstance,
     getCollectorInstance,
     signWithAddress,
-    contractNetworks
+    contractNetworks,
+    getTransactionReceipt
 } = require('./utils');
 const argv = yargs(hideBin(process.argv)).parserConfiguration({
     'parse-numbers': false
@@ -93,7 +94,7 @@ module.exports = async (callback) => {
         // we need to manually set the gasLimit in order to execute multisig tx on rsk
         gasLimit: '1081903'
     });
-    await safeTxResponse.transactionResponse?.wait();
+    await getTransactionReceipt(web3, safeTxResponse.hash);
 
     console.log('---Token balance after---');
     await printStatus(collectorAddress, owners, testTokenInstance);


### PR DESCRIPTION
## What

- Change the code that waits for the transaction receipt. Although that code was retrieved from the official documentation, it doesn't work as expected resulting in timing-related errors.

## Why

- We want to wait for the transaction receipt to be available otherwise, unexpected errors are raised showing that the transactions were not signed by other owners. 
