### PR TITLE
PP-94: Fix truffle typings patch

### DIFF
--- a/contracts/smartwallet/CustomSmartWallet.sol
+++ b/contracts/smartwallet/CustomSmartWallet.sol
@@ -125,9 +125,9 @@ contract CustomSmartWallet is IForwarder {
             address feesReceiver = req.collectorContract;
             if(feesReceiver == address(0)){
                 // pay worker if no collector contract is specified
+                /* solhint-disable avoid-tx-origin */
                 feesReceiver = tx.origin;
             }
-            /* solhint-disable avoid-tx-origin */
             (success, ret) = req.tokenContract.call{gas: req.tokenGas}(
                 abi.encodeWithSelector(
                     hex"a9059cbb", 

--- a/contracts/smartwallet/SmartWallet.sol
+++ b/contracts/smartwallet/SmartWallet.sol
@@ -114,9 +114,9 @@ contract SmartWallet is IForwarder {
             address feesReceiver = req.collectorContract;
             if(feesReceiver == address(0)){
                 // pay worker if no collector contract is specified
+                /* solhint-disable avoid-tx-origin */
                 feesReceiver = tx.origin;
             }
-            /* solhint-disable avoid-tx-origin */
             (success, ret) = req.tokenContract.call{gas: req.tokenGas}(
                 abi.encodeWithSelector(
                     hex"a9059cbb", 

--- a/patches/@openeth+truffle-typings+0.0.6.patch
+++ b/patches/@openeth+truffle-typings+0.0.6.patch
@@ -18,7 +18,6 @@ index 5de91fb..86d9264 100644
 +    tokenAmount?: BN | number | string;
 +    tokenContract?: string;
 +    forceGas?: BN | number | string;
-+    collectorContract?: string;
    }
  
    export interface TransactionLog {

--- a/patches/@openeth+truffle-typings+0.0.6.patch
+++ b/patches/@openeth+truffle-typings+0.0.6.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@openeth/truffle-typings/index.d.ts b/node_modules/@openeth/truffle-typings/index.d.ts
-index 5de91fb..86d9264 100644
+index 5de91fb..85cf390 100644
 --- a/node_modules/@openeth/truffle-typings/index.d.ts
 +++ b/node_modules/@openeth/truffle-typings/index.d.ts
-@@ -46,11 +46,14 @@ declare namespace Truffle {
+@@ -46,11 +46,15 @@ declare namespace Truffle {
      gas?: BN | number | string;
      gasPrice?: BN | number | string;
      value?: BN | string;
@@ -18,6 +18,7 @@ index 5de91fb..86d9264 100644
 +    tokenAmount?: BN | number | string;
 +    tokenContract?: string;
 +    forceGas?: BN | number | string;
++    collectorContract?: string;
    }
  
    export interface TransactionLog {

--- a/patches/@openeth+truffle-typings+0.0.6.patch
+++ b/patches/@openeth+truffle-typings+0.0.6.patch
@@ -18,6 +18,7 @@ index 5de91fb..86d9264 100644
 +    tokenAmount?: BN | number | string;
 +    tokenContract?: string;
 +    forceGas?: BN | number | string;
++    collectorContract?: string;
    }
  
    export interface TransactionLog {


### PR DESCRIPTION
## What

- Fix truffle typings patch
- Fix solhint warnings

## Why

- We may need to specify the `collectorContract` parameter, so we need to fix the type `Truffle.TransactionDetails` automatically generated by truffle.
